### PR TITLE
Optimize CI: Add APT package caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Linux system deps for Tauri
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libglib2.0-dev \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            pkg-config \
-            patchelf
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev pkg-config patchelf
+          version: 1.0
 
       - name: Cache cargo registry and target
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Adds caching for APT system dependencies to significantly speed up CI builds
- Uses `awalsh128/cache-apt-pkgs-action` for reliable package caching
- Should reduce CI time from ~1-2 minutes of apt installs to seconds on cache hit

## Current Issue
Every CI run performs these slow operations:
```bash
sudo apt-get update                    # ~15-30 seconds
sudo apt-get install -y [packages]    # ~30-60 seconds  
```

## Solution
Replace manual apt commands with specialized caching action:
- **First run**: Same speed (cache miss, installs normally)
- **Subsequent runs**: Much faster (cache hit, packages restored instantly)
- **Reliability**: Action handles all edge cases and permissions

## Packages Cached
- `libglib2.0-dev` - GLib development files
- `libgtk-3-dev` - GTK3 development files  
- `libwebkit2gtk-4.1-dev` - WebKit development files
- `libayatana-appindicator3-dev` - System tray support
- `librsvg2-dev` - SVG rendering support
- `pkg-config` - Package configuration tool
- `patchelf` - ELF patching utility

## Expected Impact
- **~50-90 seconds saved** per CI run after initial cache
- **Reduced GitHub Actions minutes** usage
- **Faster feedback** on PRs and commits

## Fallback
If caching fails, the action falls back to normal `apt install` behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)